### PR TITLE
Update new-update popup

### DIFF
--- a/css/new-update.css
+++ b/css/new-update.css
@@ -1,14 +1,4 @@
 @font-face {
-    font-family: "Inter Black";
-    src: url("chrome-extension://__MSG_@@extension_id__/resources/fonts/Inter-Black.ttf");
-}
-
-@font-face {
-    font-family: "Inter ExtraBold";
-    src: url("chrome-extension://__MSG_@@extension_id__/resources/fonts/Inter-ExtraBold.ttf");
-}
-
-@font-face {
     font-family: "Inter SemiBold";
     src: url("chrome-extension://__MSG_@@extension_id__/resources/fonts/Inter-SemiBold.ttf");
 }
@@ -18,80 +8,334 @@
     src: url("chrome-extension://__MSG_@@extension_id__/resources/fonts/Inter-Regular.ttf");
 }
 
+@font-face {
+    font-family: "Inter Bold";
+    src: url("chrome-extension://__MSG_@@extension_id__/resources/fonts/Inter-Bold.ttf");
+}
 
+#RPSS-ACU-Changelog::-webkit-scrollbar {
+    width: 10px;
+}
+
+/* Track */
+#RPSS-ACU-Changelog::-webkit-scrollbar-track {
+    background: none;
+}
+
+/* Handle */
+#RPSS-ACU-Changelog::-webkit-scrollbar-thumb {
+    background: #888;
+    border-radius: 5px;
+}
+
+/* Handle on hover */
+#RPSS-ACU-Changelog::-webkit-scrollbar-thumb:hover {
+    background: #555;
+}
 
 #RPSS-ACU-Container {
-    width: 574px;
-    height: 409px;
     background-color: #0D1117;
-    border: 3px solid #ffffff;
-    transform: translate(-50%, -50%);
+    width: 575px;
+    height: fit-content;
+    max-height: calc(100% - 150px);
     position: fixed;
-    z-index: 1050;
-    top: 50%;
-    left: 50%;
-}
-
-#RPSS-ACU-Container span {
-    color: white;
-    display: table;
-    margin: 0 auto;
-}
-
-#RPSS-ACU-Close {
-    position: relative;
-    color: #828282;
-    width: 14px;
-    height: 14px;
-    top: 10px;
-    right: 10px;
-    float: right;
-    cursor: pointer;
-}
-
-#RPSS-ACU-Name {
-    position: relative;
-    font-family: "Inter Black";
-    font-size: 32px;
-    top: 50px;
-    left: 7px;
-}
-
-#RPSS-ACU-Available {
-    position: relative;
-    font-family: "Inter ExtraBold";
-    font-size: 27px;
-    top: 80px;
-}
-
-#RPSS-ACU-Versions {
     display: flex;
-    position: relative;
-    top: 130px;
+    flex-direction: column;
+    align-items: center;
+    inset: 0px;
+    margin: auto;
+    border: 2px solid white;
+    padding: 0.25rem;
+    z-index: 1050;
 }
 
-.RPSS-ACU-Version {
-    flex: 1;
+#RPSS-ACU-Title {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
-.RPSS-ACU-Version span:nth-child(1) {
-    font-family: "Inter SemiBold";
+#RPSS-ACU-Title h1 {
+    color: white;
+    font-size: 32px;
+    font-family: "Inter Bold";
+    margin: 0px;
+}
+
+#RPSS-ACU-Title h2 {
+    color: #FFFFFFE6;
     font-size: 25px;
-}
-
-.RPSS-ACU-Version span:nth-child(2) {
-    font-family: "Inter Regular";
-    margin-top: 20px !important;
-    font-size: 24px;
-}
-
-#RPSS-ACU-Update {
-    position: relative;
     font-family: "Inter SemiBold";
-    font-size: 24px;
-    color: #2F81F7;
-    top: 200px;
+    margin: 0px;
+}
+
+#RPSS-ACU-Changelog {
+    height: fit-content;
+    overflow: auto;
+    margin: 0.75rem;
+    margin-top: 1rem;
+    margin-bottom: 2rem;
+    color: white;
+    border-top: 3px dashed #13729e;
+    border-bottom: 3px dashed #13729e;
+}
+
+#RPSS-ACU-Footer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-bottom: 0.75rem;
+}
+
+#RPSS-ACU-VersionContainer {
+    width: fit-content;
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+    padding: 5px;
+    margin-bottom: 0.8rem;
+    border-radius: 0.25rem;
+    background-color: #282828;
+}
+
+#RPSS-ACU-VersionContainer span {
+    width: 24px;
+    height: 18px;
+    background-image: url("chrome-extension://__MSG_@@extension_id__/resources/svg/arrow-right-thin.svg");
+}
+
+#RPSS-ACU-VersionContainer div {
+    display: flex;
+    font-size: 17px;
+    font-family: "Inter Regular";
+}
+
+#RPSS-ACU-VersionContainer>div:first-child p {
+    color: #FF0000;
+}
+
+#RPSS-ACU-VersionContainer>div:last-child p {
+    color: #00FF29;
+}
+
+#RPSS-ACU-VersionContainer div p {
+    margin: 0;
+    padding: 0;
+}
+
+#RPSS-ACU-ButtonContainer button {
+    color: white;
+    font-size: 17px;
+    font-family: "Inter SemiBold";
+    padding: 5px;
+    border-radius: 0.25rem;
+    border: none;
+}
+
+
+
+/* ⬇⬇⬇   Github Markdown CSS   ⬇⬇⬇ */
+
+#RPSS-ACU-Changelog {
+    font: 400 16px/1.5 "Helvetica Neue", Helvetica, Arial, sans-serif;
+    color: #fff;
+    background-color: #0D1117;
+    -webkit-text-size-adjust: 100%;
+    -webkit-font-feature-settings: "kern" 1;
+    -moz-font-feature-settings: "kern" 1;
+    -o-font-feature-settings: "kern" 1;
+    font-feature-settings: "kern" 1;
+    font-kerning: normal;
+}
+
+@media only screen and (max-width: 600px) {
+    #RPSS-ACU-Changelog {
+        padding: 5px;
+    }
+
+    #RPSS-ACU-Changelog>#content {
+        padding: 0px 20px 20px 20px !important;
+    }
+}
+
+#RPSS-ACU-Changelog>#content {
+    margin: 0px;
+    max-width: 900px;
+    border: 1px solid #e1e4e8;
+    padding: 10px 40px;
+    padding-bottom: 20px;
+    border-radius: 2px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+#RPSS-ACU-Changelog summary {
+    cursor: pointer;
     text-decoration: underline;
-    display: table;
-    margin: 0 auto;
+}
+
+#RPSS-ACU-Changelog hr {
+    color: #bbb;
+    background-color: #bbb;
+    height: 1px;
+    flex: 0 1 auto;
+    margin: 1em 0;
+    padding: 0;
+    border: none;
+}
+
+#RPSS-ACU-Changelog .hljs-operator {
+    color: #868686;
+}
+
+/* Links */
+#RPSS-ACU-Changelog a {
+    color: #0366d6;
+    text-decoration: none;
+}
+
+#RPSS-ACU-Changelog a:visited {
+    color: #0366d6;
+}
+
+#RPSS-ACU-Changelog a:hover {
+    color: #0366d6;
+    text-decoration: underline;
+}
+
+#RPSS-ACU-Changelog pre {
+    background-color: #f6f8fa;
+    border-radius: 3px;
+    font-size: 85%;
+    line-height: 1.45;
+    overflow: auto;
+    padding: 16px;
+}
+
+/* Code blocks */
+#RPSS-ACU-Changelog code {
+    background-color: rgba(27, 31, 35, .05);
+    border-radius: 3px;
+    font-size: 85%;
+    margin: 0;
+    word-wrap: break-word;
+    padding: .2em .4em;
+    font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, Courier, monospace;
+}
+
+#RPSS-ACU-Changelog pre>code {
+    background-color: transparent;
+    border: 0;
+    display: inline;
+    line-height: inherit;
+    margin: 0;
+    overflow: visible;
+    padding: 0;
+    word-wrap: normal;
+    font-size: 100%;
+}
+
+/* Blockquotes */
+#RPSS-ACU-Changelog blockquote {
+    margin-left: 30px;
+    margin-top: 0px;
+    margin-bottom: 16px;
+    border-left-width: 3px;
+    padding: 0 1em;
+    color: #828282;
+    border-left: 4px solid #e8e8e8;
+    padding-left: 15px;
+    font-size: 18px;
+    letter-spacing: -1px;
+    font-style: italic;
+}
+
+#RPSS-ACU-Changelog blockquote * {
+    font-style: normal !important;
+    letter-spacing: 0;
+    color: #6a737d !important;
+}
+
+/* Tables */
+#RPSS-ACU-Changelog table {
+    border-spacing: 2px;
+    display: block;
+    font-size: 14px;
+    overflow: auto;
+    width: 100%;
+    margin-bottom: 16px;
+    border-spacing: 0;
+    border-collapse: collapse;
+}
+
+#RPSS-ACU-Changelog td {
+    padding: 6px 13px;
+    border: 1px solid #dfe2e5;
+}
+
+#RPSS-ACU-Changelog th {
+    font-weight: 600;
+    padding: 6px 13px;
+    border: 1px solid #dfe2e5;
+}
+
+#RPSS-ACU-Changelog tr {
+    background-color: #fff;
+    border-top: 1px solid #c6cbd1;
+}
+
+#RPSS-ACU-Changelog table tr:nth-child(2n) {
+    background-color: #f6f8fa;
+}
+
+/* Others */
+#RPSS-ACU-Changelog img {
+    max-width: 100%;
+}
+
+#RPSS-ACU-Changelog p {
+    line-height: 24px;
+    font-weight: 400;
+    font-size: 16px;
+    color: #e6edf3;
+}
+
+#RPSS-ACU-Changelog ul {
+    margin-top: 0;
+}
+
+#RPSS-ACU-Changelog li {
+    color: #e6edf3;
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 1.5;
+}
+
+#RPSS-ACU-Changelog li+li {
+    margin-top: 0.25em;
+}
+
+#RPSS-ACU-Changelog * {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    color: #e6edf3;
+}
+
+#RPSS-ACU-Changelog h1,
+#RPSS-ACU-Changelog h2,
+#RPSS-ACU-Changelog h3 {
+    border-bottom: 1px solid #eaecef;
+    color: #fff;
+}
+
+#RPSS-ACU-Changelog code>* {
+    font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace !important;
+}
+
+#RPSS-ACU-Background {
+    position: fixed;
+    inset: 0px;
+    width: 100%;
+    height: 100%;
+    background-color: #00000080;
+    z-index: 1049;
 }

--- a/js/content.js
+++ b/js/content.js
@@ -6,59 +6,135 @@ function autoCheckUpdate() {
     const githubOwner = "Raihann22";
     const githubRepo = "Roblox-Player-Server-Searcher";
 
-    chrome.storage.local.get(null, async (RPSS) => {
-        const currentDate = Math.floor(Date.now() / 1000);
-        const oneDay = (currentDate - RPSS.lastUpdateAlert) / (60 * 60) > 24;
+    let RPSS;
+    const currentDate = Math.floor(Date.now() / 1000);
+
+    chrome.storage.local.get(null, async (res) => {
+        RPSS = res;
+        const oneDay = ((currentDate - RPSS.lastUpdateAlert) / (60 * 60)) > 24;
 
         /**
-         *  after user closing new update alert, it will show the alert again in 24 hours (if there is an update)
+         *  [oneDay] will be false if user choose 'Remind in 24 hours', if its pass 24 hours, it will be true
          *  if its equal or more than 24 hours, it will check if there an update every 30 minutes (only when change tab/reload)
+         *  if its 30 mins cooldown and there is new version, it will use the cache instead fatching again to save rate limit API
          */
-        if (!oneDay || (currentDate - RPSS.lastCheckUpdate) / 60 < 30) return;
 
-        const availableVersion = await fetch(`https://api.github.com/repos/${githubOwner}/${githubRepo}/releases/latest`).then(async response => {
+        if (!oneDay || ((currentDate - RPSS.lastCheckUpdate) / 60) < 30) {
+            if (!RPSS.cacheLatestVersion) return;
+        } else {
+            RPSS.cacheLatestVersion = "";
+        }
+
+        const [availableVersion, changelog] = await fetchVersion();
+
+        // if there is no newer version or user skip the new version, it will return
+        if (!availableVersion || availableVersion === RPSS.skipUpdateVersion) return;
+
+        const currentVersion = chrome.runtime.getManifest().version;
+        if (thereIsNewVersion(currentVersion.split("."), availableVersion.split("."))) {
+            const updateAlert = await showUpdate(currentVersion, availableVersion, changelog);
+            updateAlert.style.visibility = "visible";
+
+            document.getElementById("RPSS-ACU-SkipVersion").addEventListener("click", async () => {
+                updateAlert.parentNode.removeChild(updateAlert);
+                await chrome.storage.local.set({
+                    skipUpdateVersion: availableVersion,
+                    cacheLatestVersion: "",
+                    cacheLatestChangelogMarkdown: ""
+                });
+            });
+
+            document.getElementById("RPSS-ACU-RemindLater").addEventListener("click", async () => {
+                updateAlert.parentNode.removeChild(updateAlert);
+                await chrome.storage.local.set({
+                    lastUpdateAlert: currentDate,
+                    cacheLatestVersion: "",
+                    cacheLatestChangelogMarkdown: ""
+                });
+            });
+
+            document.getElementById("RPSS-ACU-ManualUpdate").addEventListener("click", () => {
+                window.open(`https://github.com/${githubOwner}/${githubRepo}#how-to-download-and-install-or-update`, "_blank");
+            });
+
+            await chrome.storage.local.set({ cacheLatestVersion: availableVersion });
+        } else {
+            // clearing cache to save storage
+            await chrome.storage.local.set({
+                lastCheckUpdate: currentDate,
+                cacheLatestVersion: "",
+                cacheLatestChangelogMarkdown: ""
+            });
+        }
+    });
+
+    async function fetchVersion() {
+        if (RPSS.cacheLatestVersion) {
+            return [RPSS.cacheLatestVersion];
+        }
+
+        return await fetch(`https://api.github.com/repos/${githubOwner}/${githubRepo}/releases/latest`).then(async response => {
             const isRateLimitExceeded = response.status === 403;
             const rateLimitReset = Number(response.headers.get("x-ratelimit-reset")) - 1740;
             const result = await response.json();
             const version = result.tag_name;
 
-            RPSS.lastCheckUpdate = isRateLimitExceeded ? rateLimitReset : currentDate;
-            await chrome.storage.local.set(RPSS);
+            await chrome.storage.local.set({ lastCheckUpdate: isRateLimitExceeded ? rateLimitReset : currentDate });
 
             if (isRateLimitExceeded || !version) return;
-            return version.slice(1);
+            return [version.slice(1), result.body];
         });
+    }
 
-        if (!availableVersion) return;
+    function thereIsNewVersion(version1, version2) {
+        // Loop through each segment of the versions
+        for (let i = 0; i < version1.length; i++) {
+            let v1 = parseInt(version1[i], 10);
+            let v2 = parseInt(version2[i], 10);
 
-        const currentVersion = chrome.runtime.getManifest().version;
-        if (currentVersion !== availableVersion) {
-            RPSS.lastCheckUpdate = 0;
-            await chrome.storage.local.set(RPSS);
-
-            const container = await showUpdate(currentVersion, availableVersion);
-            container.children[0].addEventListener("click", async () => {   // close alert
-                container.hidden = true;
-                RPSS.lastUpdateAlert = currentDate;
-                await chrome.storage.local.set(RPSS);
-            });
+            // Compare corresponding segments
+            if (v2 > v1) {
+                return true;  // version2 is newer
+            } else if (v1 > v2) {
+                return false; // version1 is newer
+            }
+            // If they are equal, move to the next segment
         }
-    });
+        // If all segments are equal, return false
+        return false;
+    }
 
-    async function showUpdate(currentVersion, availableVersion) {
-        return await fetch(chrome.runtime.getURL("resources/html/new-update.html")).then(x => x.text()).then(html => {
-            const updateAlert = document.createElement("div");
+    async function showUpdate(currentVersion, availableVersion, changelog) {
+        return await fetch(chrome.runtime.getURL("resources/html/new-update.html")).then(x => x.text()).then(async html => {
+            let updateAlert = document.createElement("div");
             const body = document.body;
             body.firstChild ? body.insertBefore(updateAlert, body.firstChild) : body.appendChild(updateAlert);
             updateAlert.outerHTML = html;
 
-            const container = document.getElementById("RPSS-ACU-Container");
-            container.children[0].style.backgroundImage = `url(${chrome.runtime.getURL("resources/svg/close.svg")}`;      // close icon
-            container.children[3].children[0].children[1].innerText = `v${currentVersion}`;                     // current version
-            container.children[3].children[1].children[1].innerText = `v${availableVersion}`;                   // available version
-            container.lastElementChild.href = `https://github.com/${githubOwner}/${githubRepo}#how-to-download-and-install-or-update`;      // link to readme
+            const changelogDiv = document.createElement('div');
+            changelogDiv.style = "margin-top: 10px; margin-bottom: 10px;"
+            changelogDiv.innerHTML = RPSS.cacheLatestVersion ? RPSS.cacheLatestChangelogMarkdown : await githubMarkdown(changelog);
+            document.getElementById("RPSS-ACU-Changelog").appendChild(changelogDiv);
 
-            return container;
+            document.getElementById("RPSS-ACU-CurrentVersion").innerText = `v${currentVersion}`;
+            document.getElementById("RPSS-ACU-NewVersion").innerText = `v${availableVersion}`;
+
+            return document.getElementById("RPSS-ACU-Container").parentNode;
+        });
+    }
+
+    async function githubMarkdown(changelog) {
+        return await fetch('https://api.github.com/markdown', {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/vnd.github+json',
+                'X-GitHub-Api-Version': '2022-11-28',
+                'Content-Type': 'application/x-www-form-urlencoded'
+            },
+            body: JSON.stringify({ text: changelog.replaceAll("\\", "\\\\") })
+        }).then(res => res.text()).then(async markdownHTML => {
+            await chrome.storage.local.set({ cacheLatestChangelogMarkdown: markdownHTML });
+            return markdownHTML;
         });
     }
 }

--- a/resources/html/new-update.html
+++ b/resources/html/new-update.html
@@ -1,18 +1,35 @@
-<div id="RPSS-ACU-Container">
-    <span id="RPSS-ACU-Close" title="Don't show for one day"></span>
-    <span id="RPSS-ACU-Name">Roblox Player Server Searcher</span>
-    <span id="RPSS-ACU-Available">Update Available</span>
-
-    <div id="RPSS-ACU-Versions">
-        <div class="RPSS-ACU-Version">
-            <span style="color: #FF0000;">Current Version</span>
-            <span id="RPSS-ACU-CurrentVersion">v.0.0.0</span>
+<div style="visibility: hidden;">
+    <div id="RPSS-ACU-Container">
+        <div id="RPSS-ACU-Title">
+            <h1>Roblox Player Server Searcher</h1>
+            <h2>Update Available</h2>
         </div>
-        <div class="RPSS-ACU-Version">
-            <span style="color: #00FF29;">New Version</span>
-            <span id="RPSS-ACU-AvailableVersion">v.0.0.0</span>
+
+        <div id="RPSS-ACU-Changelog">
+
+        </div>
+
+        <div id="RPSS-ACU-Footer">
+            <div id="RPSS-ACU-VersionContainer">
+                <div>
+                    <p>[Current]&nbsp;</p>
+                    <p id="RPSS-ACU-CurrentVersion">v2.2.2</p>
+                </div>
+                <span title="arrow-right-thin"></span>
+                <div>
+                    <p id="RPSS-ACU-NewVersion">v2.2.2</p>
+                    <p>&nbsp;[New]</p>
+                </div>
+            </div>
+
+            <div id="RPSS-ACU-ButtonContainer">
+                <button id="RPSS-ACU-SkipVersion" style="background-color: #D11A2A;">Skip this version</button>
+
+                <button id="RPSS-ACU-RemindLater" style="background-color: #D7941A;">Remind me in 24 hours</button>
+
+                <button id="RPSS-ACU-ManualUpdate" style="background-color: #116D02;">Manual Update</button>
+            </div>
         </div>
     </div>
-
-    <a id="RPSS-ACU-Update" target="_blank">Manual Update</a>
+    <div id="RPSS-ACU-Background"></div>
 </div>

--- a/resources/svg/arrow-right-thin.svg
+++ b/resources/svg/arrow-right-thin.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="18" viewBox="0 0 24 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15.3978 18V10.8H0.0516124L0 7.182H15.3978V0L24 9L15.3978 18Z" fill="white"/>
+</svg>

--- a/resources/svg/close.svg
+++ b/resources/svg/close.svg
@@ -1,3 +1,0 @@
-<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M8.46 7L14 12.54V14H12.54L7 8.46L1.46 14H0V12.54L5.54 7L0 1.46V0H1.46L7 5.54L12.54 0H14V1.46L8.46 7Z" fill="#828282"/>
-</svg>


### PR DESCRIPTION
## New
1. Changelog
2. "Skip Version" button
3. "Remind in 24 hours" button

## Fix
- The HTML is now responsive.
- Version comparison is now correct! (Previously, the update popup was still showing even if the version was newer than the latest release.)
- The update information is now stored in local storage instead of fetching it repeatedly if the user reloads the page while the popup is still open. It will use the data from local storage instead of fetching it again.